### PR TITLE
JsonResponse fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "ext-json": "*",
     "packaged/helpers": "^1.9||^2.0",
     "packaged/config": "^1.2",

--- a/src/Responses/JsonResponse.php
+++ b/src/Responses/JsonResponse.php
@@ -7,17 +7,17 @@ class JsonResponse extends Response
 {
   public static function create($object = null, $status = 200, $headers = [])
   {
-    return static::raw(json_encode($object), $status, $headers);
+    return static::raw(json_encode($object, JSON_INVALID_UTF8_SUBSTITUTE), $status, $headers);
   }
 
   public static function prefixed($object = null, $status = 200, $headers = [], $prefix = ')]}\'')
   {
-    return static::raw($prefix . json_encode($object), $status, $headers);
+    return static::raw($prefix . json_encode($object, JSON_INVALID_UTF8_SUBSTITUTE), $status, $headers);
   }
 
   public static function p($responseKey, $object, $status = 200, $headers = [])
   {
-    $responseObject = json_encode($object);
+    $responseObject = json_encode($object, JSON_INVALID_UTF8_SUBSTITUTE);
     return static::raw("{$responseKey}({$responseObject})", $status, $headers);
   }
 


### PR DESCRIPTION
- Added JSON_INVALID_UTF8_SUBSTITUTE to json_encode in the JsonResponse class to fix non utf-8 characters issues

- Raised php version